### PR TITLE
fix close with poison-pill

### DIFF
--- a/VeriLogJava/src/main/java/io/github/em/verilog/logger/LogEvent.java
+++ b/VeriLogJava/src/main/java/io/github/em/verilog/logger/LogEvent.java
@@ -9,6 +9,9 @@ final class LogEvent {
     final Map<String, Object> fields;
     final Instant ts;
 
+    static final LogEvent POISON =
+            new LogEvent(null, null, null, null);
+
     LogEvent(VeriLoggerConfig.Level level, String message, Map<String, Object> fields, Instant ts) {
         this.level = level;
         this.message = message;

--- a/VeriLogJava/src/main/java/io/github/em/verilog/logger/VeriLoggerConfig.java
+++ b/VeriLogJava/src/main/java/io/github/em/verilog/logger/VeriLoggerConfig.java
@@ -49,6 +49,9 @@ public final class VeriLoggerConfig {
 
     public boolean rotateOnStartup = true;
 
+    public boolean installShutdownHook = true;
+    public long shutdownTimeoutMs = 5000; // secure Default
+
     public void validate() {
         Objects.requireNonNull(logDir, "logDir");
         Objects.requireNonNull(actor, "actor");


### PR DESCRIPTION
# Deterministic Writer Shutdown

## Problem

The async writer thread could terminate before draining the event queue, leading to lost log events on fast JVM shutdown. In practice this resulted in files containing only the header without frames.

---

## Changes

* Added `LogEvent.POISON` as explicit stop signal.
* Introduced `CountDownLatch terminated` to coordinate shutdown.
* `close()` now:

  * Enqueues poison pill.
  * Awaits writer termination with timeout.
* Writer thread:

  * Drains remaining queue entries before exit.
  * Flushes and closes file in `finally`.
  * Signals termination via latch.
* Writer thread is no longer daemon-based.
* Optional shutdown hook performs best-effort close.

---

## Result

`close()` is now deterministic:

* Queue fully drained
* All frames written
* File flushed and closed
* Writer thread terminated

No artificial delays required.

---