### PR TITLE
Restructure VerilogReader architecture + tests

### DIFF
--- a/VeriLogJava/src/main/java/io/github/em/verilog/logger/VeriLogger.java
+++ b/VeriLogJava/src/main/java/io/github/em/verilog/logger/VeriLogger.java
@@ -120,16 +120,16 @@ public final class VeriLogger implements Closeable {
     public void close(long timeoutMs) throws IOException {
         if (!closed.compareAndSet(false, true)) return;
 
-        // Hook entfernen, damit close nicht doppelt durch Hook + User läuft
+        // Remove hook that close does not run duoble hook + user
         if (shutdownHook != null) {
             try {
                 Runtime.getRuntime().removeShutdownHook(shutdownHook);
             } catch (IllegalStateException ignored) {
-                // JVM ist schon im Shutdown -> removeShutdownHook nicht erlaubt, ok.
+                // JVM is in shutdown -> removeShutdownHook not allowed. valid
             }
         }
 
-        // 1) Poison Pill rein (oder queue.close())
+        // 1) Poisin pill
         long deadline = System.currentTimeMillis() + Math.max(0, timeoutMs);
         boolean offered = false;
         while (!offered && System.currentTimeMillis() < deadline) {
@@ -141,14 +141,14 @@ public final class VeriLogger implements Closeable {
             }
         }
 
-        // 2) Warten bis Writer wirklich fertig ist
+        // 2) Wait until writer finished
         long remaining = deadline - System.currentTimeMillis();
         if (remaining < 0) remaining = 0;
 
         try {
             boolean ok = terminated.await(remaining, TimeUnit.MILLISECONDS);
             if (!ok) {
-                // Notfall: best effort und hart melden
+                // Best effort and throw
                 writer.flushAndCloseBestEffort();
                 throw new IOException("Timed out waiting for writer thread to terminate.");
             }

--- a/VeriLogJava/src/main/java/io/github/em/verilog/reader/FramedFileReader.java
+++ b/VeriLogJava/src/main/java/io/github/em/verilog/reader/FramedFileReader.java
@@ -143,7 +143,51 @@ public final class FramedFileReader implements AutoCloseable {
         }
     }
 
-    private void readFully(ByteBuffer buf) throws IOException {
+    public Iterable<Frame> frames(boolean tolerateTrailingPartial) {
+        return () -> new java.util.Iterator<>() {
+            private Frame next;
+            private boolean fetched = false;
+
+            private void fetch() throws VeriLogIoException, VeriLogFormatException {
+                if (!fetched) {
+                    next = readNextFrame(tolerateTrailingPartial);
+                    fetched = true;
+                }
+            }
+
+            @Override
+            public boolean hasNext() {
+                try {
+                    fetch();
+                } catch (VeriLogIoException e) {
+                    throw new RuntimeException(e);
+                } catch (VeriLogFormatException e) {
+                    throw new RuntimeException(e);
+                }
+                return next != null;
+            }
+
+            @Override
+            public Frame next() {
+                try {
+                    fetch();
+                } catch (VeriLogIoException e) {
+                    throw new RuntimeException(e);
+                } catch (VeriLogFormatException e) {
+                    throw new RuntimeException(e);
+                }
+                if (next == null) {
+                    throw new java.util.NoSuchElementException();
+                }
+                Frame result = next;
+                fetched = false;
+                next = null;
+                return result;
+            }
+        };
+    }
+
+            private void readFully(ByteBuffer buf) throws IOException {
         while (buf.hasRemaining()) {
             int r = ch.read(buf);
             if (r == -1) throw new EOFException();

--- a/VeriLogJava/src/main/java/io/github/em/verilog/reader/VeriLogReader.java
+++ b/VeriLogJava/src/main/java/io/github/em/verilog/reader/VeriLogReader.java
@@ -15,154 +15,262 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.em.verilog.CanonicalJson;
 import io.github.em.verilog.CryptoUtil;
 import io.github.em.verilog.crypto.XChaCha20Poly1305;
-import io.github.em.verilog.errors.VeriLogCryptoException;
-import io.github.em.verilog.errors.VeriLogException;
-import io.github.em.verilog.errors.VeriLogIoException;
-import io.github.em.verilog.errors.VeriLogJsonException;
+import io.github.em.verilog.errors.*;
 import org.bouncycastle.crypto.InvalidCipherTextException;
 import org.bouncycastle.crypto.params.ECPublicKeyParameters;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Base64;
+import java.util.Objects;
+import java.util.function.Function;
+
+import static java.nio.file.Files.getLastModifiedTime;
 
 public final class VeriLogReader {
 
     private final ObjectMapper om = new ObjectMapper();
     private static final String ENTRY_HASH = "entryHash";
     private static final String CURRENT_VLOG = "current.vlog";
+    private static Path path = null;
+
     public VerifyReport verifyFile(Path vlogPath, byte[] dek32, PublicKeyResolver keyResolver)
             throws VeriLogException {
         return verifyFile(vlogPath, dek32, keyResolver, false);
     }
 
-    public VerifyReport verifyFile(Path vlogPath, byte[] dek32, PublicKeyResolver keyResolver, boolean tolerateTrailingPartialFrame)
-            throws VeriLogException {
+    public VerifyReport verifyFile(
+            Path vlogPath,
+            byte[] dek32,
+            PublicKeyResolver keyResolver,
+            boolean tolerateTrailingPartialFrame
+    ) throws VeriLogException {
 
-        if (vlogPath == null) throw new NullPointerException("vlogPath");
-        if (dek32 == null) throw new NullPointerException("dek32");
-        if (keyResolver == null) throw new NullPointerException("keyResolver");
-
-        long expectedSeq = 1;
-        String prevHashExpected = "0".repeat(64);
-        long lastOk = 0;
+        Objects.requireNonNull(vlogPath, "vlogPath");
+        Objects.requireNonNull(dek32, "dek32");
+        Objects.requireNonNull(keyResolver, "keyResolver");
+        path = vlogPath;
+        final State s = new State();
 
         try (FramedFileReader r = new FramedFileReader(vlogPath)) {
-
-            // Header JSON: if the header is not parsable, cannot verify => JSON exception
-            final JsonNode header;
-            try {
-                String headerJson = new String(r.rawHeaderJsonBytes(), StandardCharsets.UTF_8);
-                header = om.readTree(headerJson);
-            } catch (JsonProcessingException e) {
-                throw new VeriLogJsonException("json.invalid_header", e);
-            }
-
-            String aadPrefix = header.has("aad") ? header.get("aad").asText() : "VeriLog|v1";
-            byte[] aadPrefixBytes = aadPrefix.getBytes(StandardCharsets.UTF_8);
+            final Header h = readHeader(r);
 
             r.positionAtFirstFrame();
 
-            while (true) {
-                Frame f = r.readNextFrame(tolerateTrailingPartialFrame);
-                if (f == null) break;
-
-                if (f.seq != expectedSeq) {
-                    return VerifyReport.fail(f.seq, "frame seq not contiguous (expected " + expectedSeq + ")");
-                }
-                if (f.type != 1) {
-                    return VerifyReport.fail(f.seq, "unsupported frame type: " + f.type);
-                }
-
-                byte[] aad = buildAad(aadPrefixBytes, f.type, f.seq);
-
-                final byte[] plaintext;
-                try {
-                    plaintext = XChaCha20Poly1305.decrypt(dek32, f.nonce24, f.ct, aad);
-                } catch (InvalidCipherTextException e) {
-                    // expected verification failure
-                    return VerifyReport.fail(f.seq, "decrypt/auth failed");
-                }
-
-                final JsonNode signed;
-                try {
-                    signed = om.readTree(new String(plaintext, StandardCharsets.UTF_8));
-                } catch (JsonProcessingException e) {
-                    // decrypted but not JSON: treated as verification failure (content invalid)
-                    return VerifyReport.fail(f.seq, "invalid signed JSON");
-                }
-
-                // Basic required fields presence (avoid NPE)
-                if (!signed.hasNonNull("seq")
-                        || !signed.hasNonNull("prevHash")
-                        || !signed.hasNonNull(ENTRY_HASH)
-                        || !signed.hasNonNull("keyId")
-                        || !signed.hasNonNull("sig")) {
-                    return VerifyReport.fail(f.seq, "missing required fields in signed entry");
-                }
-
-                long jsonSeq = signed.get("seq").asLong();
-                if (jsonSeq != f.seq) {
-                    return VerifyReport.fail(f.seq, "json seq mismatch (json=" + jsonSeq + ")");
-                }
-
-                String prevHash = signed.get("prevHash").asText();
-                if (!prevHash.equals(prevHashExpected)) {
-                    return VerifyReport.fail(f.seq, "prevHash mismatch");
-                }
-
-                final String canonicalPayload;
-                try {
-                    canonicalPayload = canonicalizeWithout(signed);
-                } catch (VeriLogJsonException e) {
-                    // canonicalization failure is unexpected (library/JSON issue)
-                    throw e;
-                }
-
-                byte[] entryHashBytes = CryptoUtil.sha256Utf8(canonicalPayload);
-                String computedEntryHashHex = CryptoUtil.toHexLower(entryHashBytes);
-
-                String expectedEntryHashHex = signed.get(ENTRY_HASH).asText();
-                if (!computedEntryHashHex.equals(expectedEntryHashHex)) {
-                    return VerifyReport.fail(f.seq, "entryHash mismatch");
-                }
-
-                String keyId = signed.get("keyId").asText();
-                ECPublicKeyParameters pub = keyResolver.resolveByKeyIdHex(keyId);
-                if (pub == null) {
-                    return VerifyReport.fail(f.seq, "unknown keyId: " + keyId);
-                }
-
-                final byte[] sigRaw;
-                try {
-                    sigRaw = Base64.getDecoder().decode(signed.get("sig").asText());
-                } catch (IllegalArgumentException e) {
-                    return VerifyReport.fail(f.seq, "signature encoding invalid");
-                }
-
-                final boolean sigOk;
-                try {
-                    sigOk = BcEcdsaVerifier.verifyEntryHashSig(pub, entryHashBytes, sigRaw);
-                } catch (VeriLogCryptoException e) {
-                    // unexpected crypto failure
-                    throw e;
-                }
-
-                if (!sigOk) {
-                    return VerifyReport.fail(f.seq, "signature invalid");
-                }
-
-                prevHashExpected = expectedEntryHashHex;
-                expectedSeq++;
-                lastOk = f.seq;
+            for (Frame f : r.frames(tolerateTrailingPartialFrame)) {
+                VerifyReport failure = verifyOneFrame(f, s, h, dek32, keyResolver);
+                if (failure != null) return failure;
             }
 
         } catch (java.io.IOException e) {
             throw new VeriLogIoException("io.read_failed", e, vlogPath.toString());
         }
 
-        return VerifyReport.success(lastOk);
+        return VerifyReport.success(s.lastOk);
     }
+
+    // ---------------------------
+    // Pipeline
+    // ---------------------------
+
+    private VerifyReport verifyOneFrame(
+            Frame f,
+            State s,
+            Header h,
+            byte[] dek32,
+            PublicKeyResolver keyResolver
+    ) throws VeriLogException {
+
+        VerifyReport r;
+
+        if ((r = verifyFrameMeta(f, s.expectedSeq)) != null) return r;
+
+        final byte[] aad = buildAad(h.aadPrefixBytes, f.type, f.seq);
+
+        final byte[] plaintext;
+        try {
+            plaintext = XChaCha20Poly1305.decrypt(dek32, f.nonce24, f.ct, aad);
+        } catch (InvalidCipherTextException e) {
+            return VerifyReport.fail(f.seq, "decrypt/auth failed");
+        }
+
+        final JsonNode signed;
+        try {
+            signed = om.readTree(new String(plaintext, StandardCharsets.UTF_8));
+        } catch (JsonProcessingException e) {
+            return VerifyReport.fail(f.seq, "invalid signed JSON");
+        }
+
+        if ((r = verifyRequiredFields(signed, f)) != null) return r;
+        if ((r = verifyJsonSeqMatchesFrame(signed, f)) != null) return r;
+        if ((r = verifyPrevHashMatches(signed, f, s.prevHashExpected)) != null) return r;
+
+        final CanonicalAndHash ch = canonicalizeAndHash(signed, f);
+        if (ch.failure != null) return ch.failure;
+
+        final ECPublicKeyParameters pub = resolveKeyOrFail(signed, keyResolver, f);
+        if (pub == null) return VerifyReport.fail(f.seq, "unknown keyId"); // should not happen
+
+        final byte[] sigRaw = decodeSignatureOrFail(signed, f);
+        if (sigRaw == null) return VerifyReport.fail(f.seq, "signature encoding invalid");
+
+        final boolean sigOk;
+        try {
+            sigOk = BcEcdsaVerifier.verifyEntryHashSig(pub, ch.entryHashBytes, sigRaw);
+        } catch (VeriLogCryptoException e) {
+            // unexpected crypto failure (engine/provider/etc)
+            throw e;
+        }
+
+        if (!sigOk) {
+            return VerifyReport.fail(f.seq, "signature invalid");
+        }
+
+        // Update state (single place, after full success)
+        s.prevHashExpected = ch.expectedEntryHashHex;
+        s.expectedSeq++;
+        s.lastOk = f.seq;
+
+        return null;
+    }
+
+    // ---------------------------
+    // Header
+    // ---------------------------
+
+    private Header readHeader(FramedFileReader r) throws VeriLogException {
+        final byte[] raw = r.rawHeaderJsonBytes();
+        if (raw == null || raw.length == 0) {
+            throw new VeriLogFormatException("format.missing_header", path.toString());
+        }
+        final JsonNode header;
+        try {
+            String headerJson = new String(r.rawHeaderJsonBytes(), StandardCharsets.UTF_8);
+            header = om.readTree(headerJson);
+        } catch (JsonProcessingException e) {
+            throw new VeriLogJsonException("json.invalid_header", e);
+        }
+
+        String aadPrefix = header.has("aad") ? header.get("aad").asText() : "VeriLog|v1";
+        return new Header(aadPrefix.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static final class Header {
+        final byte[] aadPrefixBytes;
+
+        Header(byte[] aadPrefixBytes) {
+            this.aadPrefixBytes = aadPrefixBytes;
+        }
+    }
+
+    private static final class State {
+        long expectedSeq = 1;
+        String prevHashExpected = "0".repeat(64);
+        long lastOk = 0;
+    }
+
+    // ----------------------------------------------
+    // Checks (fail -> VerifyReport, success -> null)
+    // ---------------------------------------------
+
+    private VerifyReport verifyFrameMeta(Frame f, long expectedSeq) {
+        Objects.requireNonNull(f, "frame");
+
+        if (f.seq != expectedSeq) {
+            return VerifyReport.fail(f.seq, "frame seq not contiguous (expected " + expectedSeq + ")");
+        }
+        if (f.type != 1) {
+            return VerifyReport.fail(f.seq, "unsupported frame type: " + f.type);
+        }
+        return null;
+    }
+
+    private VerifyReport verifyRequiredFields(JsonNode signed, Frame f) {
+        if (!signed.hasNonNull("seq")
+                || !signed.hasNonNull("prevHash")
+                || !signed.hasNonNull(ENTRY_HASH)
+                || !signed.hasNonNull("keyId")
+                || !signed.hasNonNull("sig")) {
+            return VerifyReport.fail(f.seq, "missing required fields in signed entry");
+        }
+        return null;
+    }
+
+    private VerifyReport verifyJsonSeqMatchesFrame(JsonNode signed, Frame f) {
+        long jsonSeq = signed.get("seq").asLong();
+        if (jsonSeq != f.seq) {
+            return VerifyReport.fail(f.seq, "json seq mismatch (json=" + jsonSeq + ")");
+        }
+        return null;
+    }
+
+    private VerifyReport verifyPrevHashMatches(JsonNode signed, Frame f, String prevHashExpected) {
+        String prevHash = signed.get("prevHash").asText();
+        if (!prevHash.equals(prevHashExpected)) {
+            return VerifyReport.fail(f.seq, "prevHash mismatch");
+        }
+        return null;
+    }
+
+    private static final class CanonicalAndHash {
+        final byte[] entryHashBytes;
+        final String expectedEntryHashHex;
+        final VerifyReport failure;
+
+        private CanonicalAndHash(byte[] entryHashBytes, String expectedEntryHashHex, VerifyReport failure) {
+            this.entryHashBytes = entryHashBytes;
+            this.expectedEntryHashHex = expectedEntryHashHex;
+            this.failure = failure;
+        }
+
+        static CanonicalAndHash fail(VerifyReport r) {
+            return new CanonicalAndHash(null, null, r);
+        }
+
+        static CanonicalAndHash ok(byte[] bytes, String expectedHex) {
+            return new CanonicalAndHash(bytes, expectedHex, null);
+        }
+    }
+
+    private CanonicalAndHash canonicalizeAndHash(JsonNode signed, Frame f) throws VeriLogException {
+        final String canonicalPayload;
+        try {
+            canonicalPayload = canonicalizeWithout(signed);
+        } catch (VeriLogJsonException e) {
+            // unexpected (library/JSON issue)
+            throw e;
+        }
+
+        byte[] entryHashBytes = CryptoUtil.sha256Utf8(canonicalPayload);
+        String computedEntryHashHex = CryptoUtil.toHexLower(entryHashBytes);
+
+        String expectedEntryHashHex = signed.get(ENTRY_HASH).asText();
+        if (!computedEntryHashHex.equals(expectedEntryHashHex)) {
+            return CanonicalAndHash.fail(VerifyReport.fail(f.seq, "entryHash mismatch"));
+        }
+
+        return CanonicalAndHash.ok(entryHashBytes, expectedEntryHashHex);
+    }
+
+    private ECPublicKeyParameters resolveKeyOrFail(JsonNode signed, PublicKeyResolver keyResolver, Frame f) {
+        String keyId = signed.get("keyId").asText();
+        ECPublicKeyParameters pub = keyResolver.resolveByKeyIdHex(keyId);
+        if (pub == null) {
+            // expected verification failure
+            return null;
+        }
+        return pub;
+    }
+
+    private byte[] decodeSignatureOrFail(JsonNode signed, Frame f) {
+        try {
+            return Base64.getDecoder().decode(signed.get("sig").asText());
+        } catch (IllegalArgumentException e) {
+            // expected verification failure
+            return null;
+        }
+    }
+
 
     public DirectoryVerifyReport verifyDirectory(Path logDir, byte[] dek32, PublicKeyResolver keyResolver)
             throws VeriLogException {
@@ -172,59 +280,57 @@ public final class VeriLogReader {
     /**
      * @param stopOnFirstFailure if true: stop at first failed file
      */
-    public DirectoryVerifyReport verifyDirectory(Path logDir, byte[] dek32, PublicKeyResolver keyResolver, boolean stopOnFirstFailure)
-            throws VeriLogException {
+    public DirectoryVerifyReport verifyDirectory(
+            Path logDir,
+            byte[] dek32,
+            PublicKeyResolver keyResolver,
+            boolean stopOnFirstFailure
+    ) throws VeriLogException {
 
-        if (logDir == null) throw new NullPointerException("logDir");
-        if (dek32 == null) throw new NullPointerException("dek32");
-        if (keyResolver == null) throw new NullPointerException("keyResolver");
+        Objects.requireNonNull(logDir, "logDir");
+        Objects.requireNonNull(dek32, "dek32");
+        Objects.requireNonNull(keyResolver, "keyResolver");
 
         var report = new DirectoryVerifyReport();
 
-        // list *.vlog, skip directories
-        java.util.List<java.nio.file.Path> files = new java.util.ArrayList<>();
+        var files = listVlogFiles(logDir);
+        sortVlogFiles(files);
+
+        for (Path f : files) {
+            boolean tolerate = isCurrentVlog(f);
+            VerifyReport r = verifyFile(f, dek32, keyResolver, tolerate);
+
+            report.add(new DirectoryVerifyReport.FileResult(f, r.valid, r.seq, r.reason));
+
+            if (stopOnFirstFailure && !r.valid) break;
+        }
+        return report;
+    }
+
+    private static java.util.List<Path> listVlogFiles(Path logDir) throws VeriLogException {
+        java.util.List<Path> files = new java.util.ArrayList<>();
         try (var stream = java.nio.file.Files.list(logDir)) {
             stream
-                    .filter(p -> java.nio.file.Files.isRegularFile(p))
+                    .filter(java.nio.file.Files::isRegularFile)
                     .filter(p -> p.getFileName().toString().endsWith(".vlog"))
                     .forEach(files::add);
         } catch (java.io.IOException e) {
             throw new VeriLogIoException("io.read_failed", e, logDir.toString());
         }
+        return files;
+    }
 
-        // Sort: name first, then lastModified
-        files.sort((a, b) -> {
-            int c = a.getFileName().toString().compareTo(b.getFileName().toString());
-            if (c != 0) return c;
-            try {
-                long ta = java.nio.file.Files.getLastModifiedTime(a).toMillis();
-                long tb = java.nio.file.Files.getLastModifiedTime(b).toMillis();
-                return Long.compare(ta, tb);
-            } catch (java.io.IOException ignored) {
-                return 0;
-            }
-        });
+    private static void sortVlogFiles(java.util.List<Path> files) {
+        // One comparator instead of two sorts
+        files.sort(
+                java.util.Comparator
+                        .comparing((Path p) -> p.getFileName().toString().equals(CURRENT_VLOG)) // false first, current last
+                        .thenComparing(p -> p.getFileName().toString())
+        );
+    }
 
-        // current.vlog last
-        files.sort((a, b) -> {
-            String an = a.getFileName().toString();
-            String bn = b.getFileName().toString();
-            boolean ac = an.equals(CURRENT_VLOG);
-            boolean bc = bn.equals(CURRENT_VLOG);
-            if (ac == bc) return 0;
-            return ac ? 1 : -1;
-        });
-
-        for (var f : files) {
-            boolean tolerate = f.getFileName().toString().equals(CURRENT_VLOG);
-            VerifyReport r = verifyFile(f, dek32, keyResolver, tolerate);
-
-            report.add(new DirectoryVerifyReport.FileResult(f, r.valid, r.seq, r.reason));
-
-            if (!r.valid && stopOnFirstFailure) break;
-        }
-
-        return report;
+    private static boolean isCurrentVlog(Path p) {
+        return p.getFileName().toString().equals(CURRENT_VLOG);
     }
 
     private byte[] buildAad(byte[] prefix, byte type, long seq) {

--- a/VeriLogJava/src/main/java/io/github/em/verilog/reader/VerifyReport.java
+++ b/VeriLogJava/src/main/java/io/github/em/verilog/reader/VerifyReport.java
@@ -12,7 +12,7 @@ package io.github.em.verilog.reader;
 public final class VerifyReport {
     public final boolean valid;
     public final long seq;       // seq where it failed (or last verified)
-    public final String reason;  // null if success
+    public final String reason;  // null if ok
 
     private VerifyReport(boolean valid, long seq, String reason) {
         this.valid = valid;

--- a/VeriLogJava/src/main/resources/messages.properties
+++ b/VeriLogJava/src/main/resources/messages.properties
@@ -30,6 +30,7 @@ format.hex.invalid_char=Invalid hex character: {0}
 format.pem.base64_invalid=PEM base64 content is invalid
 format.pem.public_key_invalid=Invalid EC public key PEM
 format.key.not_ec_private=Private key is not an EC P-256 key
+format.missing_header=The file does not contain a valid header section {0}
 
 # JSON
 json.invalid_header=Invalid header JSON

--- a/VeriLogJava/src/test/java/io/github/em/verilog/io/FramedLogFileTest.java
+++ b/VeriLogJava/src/test/java/io/github/em/verilog/io/FramedLogFileTest.java
@@ -2,9 +2,12 @@ package io.github.em.verilog.io;
 
 import io.github.em.verilog.CryptoUtil;
 import io.github.em.verilog.errors.VeriLogException;
+import io.github.em.verilog.errors.VeriLogFormatException;
 import io.github.em.verilog.errors.VeriLogIoException;
+import io.github.em.verilog.reader.FramedFileReader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedConstruction;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -64,7 +67,7 @@ public class FramedLogFileTest {
         }
 
         try (FramedLogFile f2 = FramedLogFile.openOrCreate(file, dek, "aad")) {
-            // after recovery we keep seq=1 and seq=2 -> next is 3
+            // after recovery keep seq=1 and seq=2 -> next is 3
             assertEquals(3, f2.nextSeq(), "Should recover to seq=3 (max=2) after truncating partial last frame");
         }
     }
@@ -126,4 +129,27 @@ public class FramedLogFileTest {
         FramedLogFile.closeOnInitFailure(null, init);
         assertEquals(0, init.getSuppressed().length);
     }
+
+
+    @Test
+    void next_should_throw_NoSuchElementException_when_no_more_frames() {
+        try (MockedConstruction<FramedFileReader> mocked =
+                     mockConstruction(FramedFileReader.class, (mock, ctx) -> {
+                         when(mock.readNextFrame(false)).thenReturn(null); // EOF
+                     })) {
+
+            FramedFileReader r = new FramedFileReader(Path.of("dummy.vlog"));
+            var it = r.frames(false).iterator();
+
+            assertFalse(it.hasNext());
+            assertThrows(java.util.NoSuchElementException.class, it::next);
+        } catch (VeriLogIoException e) {
+            throw new RuntimeException(e);
+        } catch (VeriLogFormatException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }
+
+
+

--- a/VeriLogJava/src/test/java/io/github/em/verilog/reader/VeriLogReaderE2ETest.java
+++ b/VeriLogJava/src/test/java/io/github/em/verilog/reader/VeriLogReaderE2ETest.java
@@ -65,7 +65,7 @@ class VeriLogReaderE2ETest {
         // Flip 1 byte in the payload ciphertext (after header).
         byte[] all = Files.readAllBytes(file);
         int headerLenTotal = headerLenTotal(all);
-        // After header, layout is: len(4) + payload. We flip near the end of file (inside ct/tag).
+        // After header, layout is: len(4) + payload. Flip near the end of file (inside ct/tag).
         int flipIndex = Math.min(all.length - 10, headerLenTotal + 4 + 1 + 8 + 24 + 5);
         all[flipIndex] ^= 0x01;
         Files.write(file, all, StandardOpenOption.TRUNCATE_EXISTING);
@@ -86,7 +86,7 @@ class VeriLogReaderE2ETest {
         Path dir = Files.createTempDirectory("vlog-bad-prevhash");
         Path file = dir.resolve("current.vlog");
 
-        // Entry 2 is forced to carry a wrong prevHash (we pass it explicitly).
+        // Entry 2 is forced to carry a wrong prevHash
         writeVlogFile(file, "VeriLog|v1", tm.dek32,
                 new EntrySpec(1, "0".repeat(64), "evt1", OM.createObjectNode().put("x", 1)),
                 new EntrySpec(2, "f".repeat(64), "evt2", OM.createObjectNode().put("x", 2)) // WRONG
@@ -136,7 +136,7 @@ class VeriLogReaderE2ETest {
         Path dir = Files.createTempDirectory("vlog-bad-seq");
         Path file = dir.resolve("current.vlog");
 
-        // We'll write entries seq 1 and 3 (gap).
+        // Write entries seq 1 and 3 (gap).
         ObjectNode u1 = buildUnsignedEntry(1, "0".repeat(64), tm.keyIdHex, "evt1", OM.createObjectNode().put("x", 1));
         SignedPayload s1 = signEntry(u1, tm, false);
 

--- a/VeriLogJava/src/test/java/io/github/em/verilog/reader/VeriLogReaderTest.java
+++ b/VeriLogJava/src/test/java/io/github/em/verilog/reader/VeriLogReaderTest.java
@@ -1,19 +1,35 @@
 package io.github.em.verilog.reader;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.em.verilog.errors.VeriLogException;
+import io.github.em.verilog.errors.VeriLogFormatException;
 import io.github.em.verilog.errors.VeriLogIoException;
 import io.github.em.verilog.errors.VeriLogJsonException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 public class VeriLogReaderTest {
     private VeriLogReader reader;
     private byte[] dek32;
     private PublicKeyResolver resolver;
-
+    private static final ObjectMapper OM = new ObjectMapper();
     @BeforeEach
     void setup() {
         reader = new VeriLogReader();
@@ -115,4 +131,205 @@ public class VeriLogReaderTest {
 
         assertEquals("json.invalid_header", ex.getMessageKey());
     }
+
+    @Test
+    void should_wrap_ioexception_as_io_read_failed() throws Exception {
+        Path path = Path.of("dummy.vlog");
+        byte[] dek32 = new byte[32];
+        PublicKeyResolver resolver = mock(PublicKeyResolver.class);
+
+        byte[] headerJson = "{\"aad\":\"VeriLog|v1\"}".getBytes(StandardCharsets.UTF_8);
+
+        try (MockedConstruction<FramedFileReader> mocked =
+                     mockConstruction(FramedFileReader.class, (mock, context) -> {
+
+                         // Prevent NPE in readHeader()
+                         when(mock.rawHeaderJsonBytes()).thenReturn(headerJson);
+                         doThrow(new IOException("boom"))
+                                 .when(mock)
+                                 .positionAtFirstFrame();
+                     })) {
+
+            VeriLogReader reader = new VeriLogReader();
+
+            VeriLogIoException ex = assertThrows(
+                    VeriLogIoException.class,
+                    () -> reader.verifyFile(path, dek32, resolver, false)
+            );
+
+            assertEquals("io.read_failed", ex.getMessageKey());
+            assertTrue(ex.getCause() instanceof IOException);
+            assertEquals("boom", ex.getCause().getMessage());
+        }
+    }
+
+    @Test
+    void should_throw_when_header_empty() throws Exception {
+        Path path = Path.of("dummy.vlog");
+        byte[] dek32 = new byte[32];
+        PublicKeyResolver resolver = mock(PublicKeyResolver.class);
+
+        try (MockedConstruction<FramedFileReader> mocked =
+                     mockConstruction(FramedFileReader.class, (mock, context) -> {
+                         doThrow(new IOException("boom"))
+                                 .when(mock)
+                                 .positionAtFirstFrame();
+                     })) {
+
+            VeriLogReader reader = new VeriLogReader();
+
+            VeriLogFormatException ex = assertThrows(
+                    VeriLogFormatException.class,
+                    () -> reader.verifyFile(path, dek32, resolver, false)
+            );
+
+            assertEquals("format.missing_header", ex.getMessageKey());
+            assertEquals("The file does not contain a valid header section dummy.vlog", ex.getMessage());
+        }
+    }
+
+    @Test
+    void should_fail_when_any_required_field_missing() {
+        // given: missing "sig"
+        ObjectNode signed = OM.createObjectNode();
+        signed.put("seq", 1);
+        signed.put("prevHash", "0".repeat(64));
+        signed.put("entryHash", "a".repeat(64));
+        signed.put("keyId", "b".repeat(64));
+        // signed.put("sig", "..."); // missing
+
+        Frame f = new Frame((byte) 1, 1L, new byte[24], new byte[0]);
+
+        VeriLogReader reader = new VeriLogReader();
+
+        VerifyReport r = invokeVerifyRequiredFields(reader, signed, f);
+
+        assertNotNull(r);
+        assertFalse(r.valid);
+        assertEquals(1L, r.seq);
+        assertTrue(r.reason.contains("missing required fields"));
+    }
+
+    @Test
+    void should_wrap_files_list_ioexception_as_io_read_failed() throws Exception {
+        Path dir = Path.of("dummy-dir");
+        var reader = new VeriLogReader();
+
+        try (MockedStatic<Files> files = mockStatic(Files.class)) {
+            files.when(() -> Files.list(dir)).thenThrow(new IOException("boom"));
+
+            VeriLogIoException ex = assertThrows(
+                    VeriLogIoException.class,
+                    () -> reader.verifyDirectory(dir, new byte[32], mock(PublicKeyResolver.class), false)
+            );
+
+            assertEquals("io.read_failed", ex.getMessageKey());
+            assertTrue(ex.getCause() instanceof IOException);
+        }
+    }
+
+    @Test
+    void should_wrap_runtimeexception_as_json_canonicalize_failed() throws Exception {
+        VeriLogReader reader = new VeriLogReader();
+
+        JsonNode node = mock(JsonNode.class);
+        when(node.deepCopy()).thenThrow(new RuntimeException("boom"));
+
+        var m = VeriLogReader.class.getDeclaredMethod("canonicalizeWithout", JsonNode.class);
+        m.setAccessible(true);
+
+        VeriLogJsonException ex = assertThrows(
+                VeriLogJsonException.class,
+                () -> {
+                    try {
+                        m.invoke(reader, node);
+                    } catch (java.lang.reflect.InvocationTargetException ite) {
+                        throw ite.getCause(); // unwrap
+                    }
+                }
+        );
+
+        assertEquals("json.canonicalize_failed", ex.getMessageKey());
+        assertNotNull(ex.getCause());
+        assertEquals("boom", ex.getCause().getMessage());
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideNullValues")
+    void should_throw_when_param_is_null(Path path, byte[] dek32, PublicKeyResolver publicKeyResolver){
+            assertThrows(NullPointerException.class, () -> reader.verifyDirectory(path, dek32, publicKeyResolver));
+    }
+
+    @ParameterizedTest
+    @MethodSource("missingRequiredFieldCases")
+    void should_fail_when_required_field_missing_or_null(String field, boolean asNull) {
+        ObjectNode signed = validSigned();
+
+        if (asNull) {
+            signed.putNull(field);
+        } else {
+            signed.remove(field);
+        }
+
+        Frame f = new Frame((byte) 1, 7L, new byte[24], new byte[0]);
+        VeriLogReader reader = new VeriLogReader();
+
+        VerifyReport r = invokeVerifyRequiredFields(reader, signed, f);
+
+        assertNotNull(r);
+        assertEquals(7L, r.seq);
+        assertFalse(r.valid);
+        assertTrue(r.reason.contains("missing required fields"));
+    }
+
+    private static Stream<Arguments> provideNullValues(){
+        PublicKeyResolver resolver = mock(PublicKeyResolver.class);
+        Path path = Path.of("dummy.vlog");
+        return Stream.of(
+                Arguments.of(null, new byte[32], resolver),
+                Arguments.of(path, null, resolver),
+                Arguments.of(path, new byte[32], null)
+        );
+    }
+
+    private static Stream<Arguments> missingRequiredFieldCases() {
+        return Stream.of(
+                Arguments.of("seq", false),
+                Arguments.of("seq", true),
+                Arguments.of("prevHash", false),
+                Arguments.of("prevHash", true),
+                Arguments.of("entryHash", false),
+                Arguments.of("entryHash", true),
+                Arguments.of("keyId", false),
+                Arguments.of("keyId", true),
+                Arguments.of("sig", false),
+                Arguments.of("sig", true)
+        );
+    }
+
+    private static ObjectNode validSigned() {
+        ObjectNode signed = OM.createObjectNode();
+        signed.put("seq", 7);
+        signed.put("prevHash", "0".repeat(64));
+        signed.put("entryHash", "a".repeat(64));
+        signed.put("keyId", "b".repeat(64));
+        signed.put("sig", "AAAA");
+        return signed;
+    }
+
+    // reflection helper
+    private static VerifyReport invokeVerifyRequiredFields(VeriLogReader reader, ObjectNode signed, Frame f) {
+        try {
+            var m = VeriLogReader.class.getDeclaredMethod(
+                    "verifyRequiredFields",
+                    com.fasterxml.jackson.databind.JsonNode.class,
+                    Frame.class
+            );
+            m.setAccessible(true);
+            return (VerifyReport) m.invoke(reader, signed, f);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 }
+


### PR DESCRIPTION
## Description
This PR introduces a restructured VeriLogReader to reduce complexity and make debugging easier. Added are tests to cover the VerilogReader more extensively.

## Choice between Interator and Stream 
After careful consideration I chose the Iterator over the Stream approach. 
Due to harder resource lifecycle management, Exception wrapping and possible misue (parallel)