### PR TITLE
Introduce VerilogConfig Builder pattern + fix tests

### DIFF
--- a/VeriLogJava/src/main/java/io/github/em/verilog/logger/BackpressureEnqueuer.java
+++ b/VeriLogJava/src/main/java/io/github/em/verilog/logger/BackpressureEnqueuer.java
@@ -24,10 +24,10 @@ final class BackpressureEnqueuer {
 
     boolean enqueue(LogEvent ev) {
         try {
-            long timeoutMs = cfg.offerTimeoutMs;
+            long timeoutMs = cfg.getOfferTimeoutMs();
             boolean mustWait =
-                    cfg.backpressureMode != VeriLoggerConfig.BackpressureMode.DROP ||
-                            (cfg.preferReliabilityForWarnError &&
+                    cfg.getBackpressureMode() != VeriLoggerConfig.BackpressureMode.DROP ||
+                            (cfg.isPreferReliabilityForWarnError() &&
                                     (ev.level == VeriLoggerConfig.Level.WARN || ev.level == VeriLoggerConfig.Level.ERROR));
 
             return mustWait

--- a/VeriLogJava/src/main/java/io/github/em/verilog/logger/LogWriter.java
+++ b/VeriLogJava/src/main/java/io/github/em/verilog/logger/LogWriter.java
@@ -15,13 +15,12 @@ import io.github.em.verilog.errors.VeriLogCryptoException;
 import io.github.em.verilog.errors.VeriLogIoException;
 import io.github.em.verilog.io.FramedLogFile;
 
-import java.util.concurrent.CountDownLatch;
-
 import java.io.IOException;
 import java.nio.file.*;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -64,21 +63,21 @@ final class LogWriter implements Runnable {
         this.closed = closed;
         this.faulted = faulted;
 
-        this.flushPolicy = new FlushPolicy(cfg.flushEveryN, cfg.flushEveryMs, cfg.fsyncOnFlush);
-        this.rotationPolicy = new RotationPolicy(cfg.rotateBytes, cfg.filePrefix);
+        this.flushPolicy = new FlushPolicy(cfg.getFlushEveryN(), cfg.getFlushEveryMs(), cfg.isFsyncOnFlush());
+        this.rotationPolicy = new RotationPolicy(cfg.getRotateBytes(), cfg.getFilePrefix());
         this.terminated = terminated;
 
         try {
             Path current = currentPath();
-            Files.createDirectories(cfg.logDir);
+            Files.createDirectories(cfg.getLogDir());
 
-            if (cfg.rotateOnStartup && Files.exists(current) && Files.size(current) > 0) {
+            if (cfg.isRotateOnStartup() && Files.exists(current) && Files.size(current) > 0) {
                 rotateExistingOnStartup(current);
             }
 
 // Create file with 0600 only if it doesn't exist yet (POSIX only)
             ensureFileExistsWith0600IfPossible(current);
-            this.file = FramedLogFile.openOrCreate(current, cfg.encryptionKey32, cfg.aadPrefix);
+            this.file = FramedLogFile.openOrCreate(current, cfg.getEncryptionKey(), cfg.getAadPrefix());
             this.bytesWrittenCurrent = Files.exists(current) ? Files.size(current) : 0;
             this.lastFlushMs = System.currentTimeMillis();
         } catch (IOException e) {
@@ -194,8 +193,8 @@ final class LogWriter implements Runnable {
         try {
             byte[] signedEntryJson = signedFactory.buildSignedEntryJsonUtf8(
                     chain,
-                    cfg.signer,
-                    cfg.actor,
+                    cfg.getSigner(),
+                    cfg.getActor(),
                     ev.level.name(),
                     Map.of(
                             "msg", ev.message,
@@ -248,11 +247,11 @@ final class LogWriter implements Runnable {
             file.close();
 
             Path current = currentPath();
-            Path rotated = rotationPolicy.rotatedPath(cfg.logDir);
+            Path rotated = rotationPolicy.rotatedPath(cfg.getLogDir());
 
             moveAtomicOrReplace(current, rotated);
 
-            this.file = FramedLogFile.openOrCreate(current, cfg.encryptionKey32, cfg.aadPrefix);
+            this.file = FramedLogFile.openOrCreate(current, cfg.getEncryptionKey(), cfg.getAadPrefix());
             this.bytesWrittenCurrent = Files.size(current);
             this.sinceFlush = 0;
             this.lastFlushMs = System.currentTimeMillis();
@@ -263,7 +262,7 @@ final class LogWriter implements Runnable {
     }
 
     private void rotateExistingOnStartup(Path current) throws IOException {
-        Path rotated = rotationPolicy.rotatedPath(cfg.logDir);
+        Path rotated = rotationPolicy.rotatedPath(cfg.getLogDir());
         moveAtomicOrReplace(current, rotated);
     }
 
@@ -282,7 +281,7 @@ final class LogWriter implements Runnable {
     }
 
     private Path currentPath() {
-        return cfg.logDir.resolve(cfg.currentFileName);
+        return cfg.getLogDir().resolve(cfg.getCurrentFileName());
     }
 
     private long estimateFrameBytes(int plaintextLen) {

--- a/VeriLogJava/src/main/java/io/github/em/verilog/logger/VeriLogger.java
+++ b/VeriLogJava/src/main/java/io/github/em/verilog/logger/VeriLogger.java
@@ -16,7 +16,10 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.*;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class VeriLogger implements Closeable {
@@ -43,7 +46,7 @@ public final class VeriLogger implements Closeable {
         cfg.validate();
         this.cfg = cfg;
 
-        this.queue = new ArrayBlockingQueue<>(cfg.queueCapacity);
+        this.queue = new ArrayBlockingQueue<>(cfg.getQueueCapacity());
         this.enqueuer = new BackpressureEnqueuer(cfg, queue);
 
         this.writer = new LogWriter(cfg, queue, metrics, closed, faulted, terminated);
@@ -52,11 +55,11 @@ public final class VeriLogger implements Closeable {
         this.writerThread.setDaemon(false);
         this.writerThread.start();
 
-        if (cfg.installShutdownHook) {
+        if (cfg.isInstallShutdownHook()) {
             this.shutdownHook = new Thread(() -> {
                 try {
                     // Best-effort close with Timeout
-                    close(cfg.shutdownTimeoutMs);
+                    close(cfg.getShutdownTimeoutMs());
                 } catch (Throwable ignored) {
                     // Shutdown hook must be best-effort- ignore failures during JVM shutdown.
                     // Should not be blocked due to logging cleanup.
@@ -92,7 +95,7 @@ public final class VeriLogger implements Closeable {
 
         if (closed.get()) return;
 
-        if (faulted.get() && cfg.faultMode == VeriLoggerConfig.FaultMode.FAIL_FAST) {
+        if (faulted.get() && cfg.getFaultMode() == VeriLoggerConfig.FaultMode.FAIL_FAST) {
             throw new IllegalStateException("VeriLogger is faulted; refusing to accept logs.");
         }
         if (faulted.get()) {
@@ -115,7 +118,7 @@ public final class VeriLogger implements Closeable {
 
     @Override
     public void close() throws IOException {
-        close(cfg.shutdownTimeoutMs);
+        close(cfg.getShutdownTimeoutMs());
     }
 
     public void close(long timeoutMs) throws IOException {

--- a/VeriLogJava/src/main/java/io/github/em/verilog/logger/VeriLoggerConfig.java
+++ b/VeriLogJava/src/main/java/io/github/em/verilog/logger/VeriLoggerConfig.java
@@ -9,16 +9,56 @@
  */
 package io.github.em.verilog.logger;
 
+import io.github.em.verilog.sign.LogSigner;
+
 import java.nio.file.Path;
 import java.util.Objects;
 
 public final class VeriLoggerConfig {
 
-    public enum Level { DEBUG, INFO, WARN, ERROR }
+    private Path logDir;
+    private String filePrefix;
+    private String currentFileName;
+    private String aadPrefix;
+    /**
+     * 32 bytes DEK for XChaCha20-Poly1305
+     */
+    private  byte[] encryptionKey;
+    private  int queueCapacity;
+    private BackpressureMode backpressureMode;
+    private long offerTimeoutMs; // for BLOCK mode
+    private FaultMode faultMode;
+    /**
+     * rotate when current file exceeds this many bytes
+     */
+    private long rotateBytes = 0;
+
+    /**
+     * flush policy
+     */
+    private int flushEveryN;
+    private long flushEveryMs;
+    private boolean fsyncOnFlush;
+    private String actor;
+    private LogSigner signer;
+    /**
+     * If DROP: never drop WARN/ERROR (will block briefly instead)
+     */
+    private boolean preferReliabilityForWarnError;
+    private boolean rotateOnStartup;
+    private boolean installShutdownHook;
+    private long shutdownTimeoutMs; // secure Default
 
     public enum BackpressureMode {
         BLOCK,          // wait up to timeout
         DROP            // drop when full
+    }
+
+    public enum Level {
+        DEBUG,
+        INFO,
+        WARN,
+        ERROR
     }
 
     public enum FaultMode {
@@ -26,40 +66,105 @@ public final class VeriLoggerConfig {
         DROP_ON_FAULT   // log() silently drops (but counts)
     }
 
-    public Path logDir = Path.of("./logs");
-    public String filePrefix = "app";
-    public String currentFileName = "current.vlog";
+    public Path getLogDir() {
+        return logDir;
+    }
 
-    public String aadPrefix = "VeriLog|v1";
+    public String getFilePrefix() {
+        return filePrefix;
+    }
 
-    /** 32 bytes DEK for XChaCha20-Poly1305 */
-    public byte[] encryptionKey32;
+    public String getCurrentFileName() {
+        return currentFileName;
+    }
 
-    public int queueCapacity = 50_000;
+    public String getAadPrefix() {
+        return aadPrefix;
+    }
 
-    public BackpressureMode backpressureMode = BackpressureMode.BLOCK;
-    public long offerTimeoutMs = 50; // for BLOCK mode
+    public byte[] getEncryptionKey() {
+        return encryptionKey.clone();
+    }
 
-    public FaultMode faultMode = FaultMode.DROP_ON_FAULT;
+    public int getQueueCapacity() {
+        return queueCapacity;
+    }
 
-    /** rotate when current file exceeds this many bytes */
-    public long rotateBytes = 100L * 1024 * 1024;
+    public BackpressureMode getBackpressureMode() {
+        return backpressureMode;
+    }
 
-    /** flush policy */
-    public int flushEveryN = 500;
-    public long flushEveryMs = 1000;
-    public boolean fsyncOnFlush = false;
+    public long getOfferTimeoutMs() {
+        return offerTimeoutMs;
+    }
 
-    public String actor = "app";
-    public io.github.em.verilog.sign.LogSigner signer;
+    public FaultMode getFaultMode() {
+        return faultMode;
+    }
 
-    /** If DROP: never drop WARN/ERROR (will block briefly instead) */
-    public boolean preferReliabilityForWarnError = true;
+    public long getRotateBytes() {
+        return rotateBytes;
+    }
 
-    public boolean rotateOnStartup = true;
+    public int getFlushEveryN() {
+        return flushEveryN;
+    }
 
-    public boolean installShutdownHook = true;
-    public long shutdownTimeoutMs = 5000; // secure Default
+    public long getFlushEveryMs() {
+        return flushEveryMs;
+    }
+
+    public boolean isFsyncOnFlush() {
+        return fsyncOnFlush;
+    }
+
+    public String getActor() {
+        return actor;
+    }
+
+    public LogSigner getSigner() {
+        return signer;
+    }
+
+    public boolean isPreferReliabilityForWarnError() {
+        return preferReliabilityForWarnError;
+    }
+
+    public boolean isRotateOnStartup() {
+        return rotateOnStartup;
+    }
+
+    public boolean isInstallShutdownHook() {
+        return installShutdownHook;
+    }
+
+    public long getShutdownTimeoutMs() {
+        return shutdownTimeoutMs;
+    }
+
+    VeriLoggerConfig(Builder b) {
+        this.logDir = b.logDir;
+        this.filePrefix = b.filePrefix;
+        this.currentFileName = b.currentFileName;
+        this.aadPrefix = b.aadPrefix;
+        this.encryptionKey = b.encryptionKey == null ? null : b.encryptionKey.clone(); // important
+        this.queueCapacity = b.queueCapacity;
+        this.backpressureMode = b.backpressureMode;
+        this.offerTimeoutMs = b.offerTimeoutMs;
+        this.faultMode = b.faultMode;
+        this.rotateBytes = b.rotateBytes;
+        this.flushEveryN = b.flushEveryN;
+        this.flushEveryMs = b.flushEveryMs;
+        this.fsyncOnFlush = b.fsyncOnFlush;
+        this.actor = b.actor;
+        this.signer = b.signer;
+        this.preferReliabilityForWarnError = b.preferReliabilityForWarnError;
+        this.rotateOnStartup = b.rotateOnStartup;
+        this.installShutdownHook = b.installShutdownHook;
+        this.shutdownTimeoutMs = b.shutdownTimeoutMs;
+
+        validate();
+    }
 
     public void validate() {
         Objects.requireNonNull(logDir, "logDir");
@@ -67,7 +172,7 @@ public final class VeriLoggerConfig {
         Objects.requireNonNull(signer, "signer");
         if (filePrefix == null || filePrefix.isBlank()) throw new IllegalArgumentException("filePrefix");
         if (currentFileName == null || currentFileName.isBlank()) throw new IllegalArgumentException("currentFileName");
-        if (encryptionKey32 == null || encryptionKey32.length != 32)
+        if (encryptionKey == null || encryptionKey.length != 32)
             throw new IllegalArgumentException("encryptionKey32 must be 32 bytes");
         if (queueCapacity < 1) throw new IllegalArgumentException("queueCapacity");
         if (offerTimeoutMs < 0) throw new IllegalArgumentException("offerTimeoutMs");
@@ -75,4 +180,126 @@ public final class VeriLoggerConfig {
         if (flushEveryN < 1) throw new IllegalArgumentException("flushEveryN");
         if (flushEveryMs < 1) throw new IllegalArgumentException("flushEveryMs");
     }
+
+    public static class Builder {
+        private Path logDir = Path.of("./logs");
+        private String filePrefix = "app";
+        private String currentFileName = "current.vlog";
+        private String aadPrefix = "VeriLog|v1";
+        private byte[] encryptionKey = new byte[32];
+        private int queueCapacity = 50_000;
+        private BackpressureMode backpressureMode = BackpressureMode.BLOCK;
+        private long offerTimeoutMs = 50;
+        private FaultMode faultMode = FaultMode.DROP_ON_FAULT;
+        private long rotateBytes = 100L * 1024 * 1024;
+        private int flushEveryN = 500;
+        private long flushEveryMs = 1000;
+        private boolean fsyncOnFlush = false;
+        private String actor = "app";
+        private LogSigner signer;
+        private boolean preferReliabilityForWarnError = true;
+        private boolean rotateOnStartup = true;
+        private boolean installShutdownHook = true;
+        private long shutdownTimeoutMs = 5000;
+
+        public Builder logDir(Path logDir) {
+            this.logDir = logDir;
+            return this;
+        }
+
+        public Builder filePrefix(String filePrefix) {
+            this.filePrefix = filePrefix;
+            return this;
+        }
+
+        public Builder currentFileName(String currentFileName) {
+            this.currentFileName = currentFileName;
+            return this;
+        }
+
+        public Builder aadPrefix(String aadPrefix) {
+            this.aadPrefix = aadPrefix;
+            return this;
+        }
+
+        public Builder encryptionKey(byte[] encryptionKey) {
+            this.encryptionKey = encryptionKey.clone();
+            return this;
+        }
+
+        public Builder queueCapacity(int queueCapacity) {
+            this.queueCapacity = queueCapacity;
+            return this;
+        }
+
+        public Builder backpressureMode(BackpressureMode backpressureMode) {
+            this.backpressureMode = backpressureMode;
+            return this;
+        }
+
+        public Builder offerTimeoutMs(long offerTimeoutMs) {
+            this.offerTimeoutMs = offerTimeoutMs;
+            return this;
+        }
+
+        public Builder faultMode(FaultMode faultMode) {
+            this.faultMode = faultMode;
+            return this;
+        }
+
+        public Builder rotateBytes(long rotateBytes) {
+            this.rotateBytes = rotateBytes;
+            return this;
+        }
+
+        public Builder flushEveryN(int flushEveryN) {
+            this.flushEveryN = flushEveryN;
+            return this;
+        }
+
+        public Builder flushEveryMs(long flushEveryMs) {
+            this.flushEveryMs = flushEveryMs;
+            return this;
+        }
+
+        public Builder fsyncOnFlush(boolean fsyncOnFlush) {
+            this.fsyncOnFlush = fsyncOnFlush;
+            return this;
+        }
+
+        public Builder actor(String actor) {
+            this.actor = actor;
+            return this;
+        }
+
+        public Builder signer(LogSigner signer) {
+            this.signer = signer;
+            return this;
+        }
+
+        public Builder preferReliabilityForWarnError(boolean preferReliabilityForWarnError) {
+            this.preferReliabilityForWarnError = preferReliabilityForWarnError;
+            return this;
+        }
+
+        public Builder rotateOnStartup(boolean rotateOnStartup) {
+            this.rotateOnStartup = rotateOnStartup;
+            return this;
+        }
+
+        public Builder installShutdownHook(boolean installShutdownHook) {
+            this.installShutdownHook = installShutdownHook;
+            return this;
+        }
+
+        public Builder shutdownTimeoutMs(long shutdownTimeoutMs) {
+            this.shutdownTimeoutMs = shutdownTimeoutMs;
+            return this;
+        }
+
+        public VeriLoggerConfig build() {
+            return new VeriLoggerConfig(this);
+        }
+    }
+
 }

--- a/VeriLogJava/src/test/java/io/github/em/verilog/logger/BackpressureEnqueuerTest.java
+++ b/VeriLogJava/src/test/java/io/github/em/verilog/logger/BackpressureEnqueuerTest.java
@@ -1,5 +1,6 @@
 package io.github.em.verilog.logger;
 
+import io.github.em.verilog.sign.LogSigner;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -9,14 +10,19 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 
 class BackpressureEnqueuerTest {
 
+    LogSigner dummySigner = mock(LogSigner.class);
+
     @Test
     void should_drop_event_when_queue_is_full_and_mode_is_drop_and_level_is_info() {
-        VeriLoggerConfig cfg = new VeriLoggerConfig();
-        cfg.backpressureMode = VeriLoggerConfig.BackpressureMode.DROP;
-        cfg.preferReliabilityForWarnError = true; // doesn’t matter for INFO
+        VeriLoggerConfig cfg = new VeriLoggerConfig.Builder()
+                .backpressureMode(VeriLoggerConfig.BackpressureMode.DROP)
+                .preferReliabilityForWarnError(true)
+                .signer(dummySigner)
+                .build(); // doesn’t matter for INFO
 
         BlockingQueue<LogEvent> q = new ArrayBlockingQueue<>(1);
         BackpressureEnqueuer enq = new BackpressureEnqueuer(cfg, q);
@@ -27,12 +33,12 @@ class BackpressureEnqueuerTest {
 
     @Test
     void should_wait_and_enqueue_when_queue_is_full_and_mode_is_drop_and_level_is_warn_and_prefer_reliability_is_true() throws Exception {
-
-        VeriLoggerConfig cfg = new VeriLoggerConfig();
-        cfg.backpressureMode = VeriLoggerConfig.BackpressureMode.DROP;
-        cfg.preferReliabilityForWarnError = true;
-        cfg.offerTimeoutMs = 250;
-
+        VeriLoggerConfig cfg = new VeriLoggerConfig.Builder()
+                .backpressureMode(VeriLoggerConfig.BackpressureMode.BLOCK)
+                .preferReliabilityForWarnError(true)
+                .offerTimeoutMs(250)
+                .signer(dummySigner)
+                .build();
         BlockingQueue<LogEvent> q = new ArrayBlockingQueue<>(1);
         BackpressureEnqueuer enq = new BackpressureEnqueuer(cfg, q);
 
@@ -60,10 +66,13 @@ class BackpressureEnqueuerTest {
     }
 
     @Test
-    void should_timeout_and_return_false_when_queue_is_full_and_mode_is_block() throws Exception {
-        VeriLoggerConfig cfg = new VeriLoggerConfig();
-        cfg.backpressureMode = VeriLoggerConfig.BackpressureMode.BLOCK;
-        cfg.offerTimeoutMs = 200;
+    void should_timeout_and_return_false_when_queue_is_full_and_mode_is_block() {
+        LogSigner dummySigner = mock(LogSigner.class);
+        VeriLoggerConfig cfg = new VeriLoggerConfig.Builder()
+                .backpressureMode(VeriLoggerConfig.BackpressureMode.BLOCK)
+                .offerTimeoutMs(200)
+                .signer(dummySigner)
+                .build();
 
         BlockingQueue<LogEvent> q = new ArrayBlockingQueue<>(1);
         BackpressureEnqueuer enq = new BackpressureEnqueuer(cfg, q);

--- a/VeriLogJava/src/test/java/io/github/em/verilog/logger/LogWriterTest.java
+++ b/VeriLogJava/src/test/java/io/github/em/verilog/logger/LogWriterTest.java
@@ -2,6 +2,8 @@ package io.github.em.verilog.logger;
 
 import io.github.em.verilog.errors.VeriLogIoException;
 import io.github.em.verilog.io.FramedLogFile;
+import io.github.em.verilog.logger.utils.TestConfigBuilder;
+import io.github.em.verilog.sign.LogSigner;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedStatic;
@@ -10,10 +12,8 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.file.*;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
 import java.time.Instant;
-import java.util.*;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -36,7 +36,7 @@ final class LogWriterTest {
         var faulted = new AtomicBoolean(false);
         var terminated = new CountDownLatch(1);
 
-        var cfg = newConfig(tmp);
+        var cfg = TestConfigBuilder.configBuilder(tmp).build();
         var metrics = new LoggerMetrics(); // adjust if needed
 
         var writer = new LogWriter(cfg, queue, metrics, closed, faulted, terminated);
@@ -49,7 +49,7 @@ final class LogWriterTest {
         assertTrue(terminated.await(3, TimeUnit.SECONDS), "writer should terminate");
         assertFalse(faulted.get(), "should not fault on normal write");
 
-        Path current = tmp.resolve(cfg.currentFileName);
+        Path current = tmp.resolve(cfg.getCurrentFileName());
         assertTrue(Files.exists(current), "current log file should exist");
         assertTrue(Files.size(current) > 0, "file should not be empty");
     }
@@ -61,46 +61,51 @@ final class LogWriterTest {
         var faulted = new AtomicBoolean(false);
         var terminated = new CountDownLatch(1);
 
-        var cfg = newConfig(tmp);
-        cfg.rotateBytes = 300; // small threshold to force rotation fast
-        cfg.flushEveryN = 1;   // flush frequently for determinism
-        cfg.flushEveryMs = 1;
+        var cfg = TestConfigBuilder.configBuilder(tmp)
+                .rotateBytes(1024 * 1024) // minimum allowed
+                .flushEveryMs(1)
+                .flushEveryN(1)
+                .build();
 
-        var metrics = new LoggerMetrics();
+        var writer = new LogWriter(cfg, queue, new LoggerMetrics(), closed, faulted, terminated);
+        new Thread(writer, "logwriter-rotate-test").start();
 
-        var writer = new LogWriter(cfg, queue, metrics, closed, faulted, terminated);
-        var t = new Thread(writer, "logwriter-rotate-test");
-        t.start();
+        // ~70 KB message (UTF-8)
+        String big = "x".repeat(70 * 1024);
 
-        // write enough events to exceed rotateBytes
-        for (int i = 0; i < 50; i++) {
-            queue.put(new LogEvent(VeriLoggerConfig.Level.INFO, "msg-" + i, Map.of("i", i), Instant.now()));
+        for (int i = 0; i < 40; i++) {
+            queue.put(new LogEvent(
+                    VeriLoggerConfig.Level.INFO,
+                    big + i,
+                    Map.of("i", i),
+                    Instant.now()
+            ));
         }
+
         queue.put(LogEvent.POISON);
 
         assertTrue(terminated.await(5, TimeUnit.SECONDS), "writer should terminate");
         assertFalse(faulted.get(), "rotation path should not fault");
 
-        // RotationPolicy naming is internal; assert by directory contents:
-        // expects at least 2 files: current + at least one rotated
         try (var stream = Files.list(tmp)) {
             long count = stream.filter(Files::isRegularFile).count();
             assertTrue(count >= 2, "should create at least one rotated file plus current");
         }
-
-        Path current = tmp.resolve(cfg.currentFileName);
-        assertTrue(Files.exists(current), "current file should exist after rotation");
     }
 
     @Test
     void should_set_faulted_when_signing_fails_and_still_terminate() throws Exception {
+        LogSigner badSigner = mock(LogSigner.class);
+        when(badSigner.signEntryHash(any())).thenThrow(new RuntimeException("boom"));
+
         var queue = new LinkedBlockingQueue<LogEvent>();
         var closed = new AtomicBoolean(false);
         var faulted = new AtomicBoolean(false);
         var terminated = new CountDownLatch(1);
 
-        var cfg = newConfig(tmp);
-        cfg.signer = null; // provoke failure inside SignedEntryFactory.buildSignedEntryJsonUtf8
+        var cfg = TestConfigBuilder.configBuilder(tmp)
+                .signer(badSigner) // provoke failure inside SignedEntryFactory.buildSignedEntryJsonUtf8
+                .build();
 
         var metrics = new LoggerMetrics();
 
@@ -156,8 +161,9 @@ final class LogWriterTest {
         var faulted = new AtomicBoolean(false);
         var terminated = new CountDownLatch(1);
 
-        var cfg = newConfig(tmp);
-        cfg.rotateBytes = 1;
+        var cfg = TestConfigBuilder.configBuilder(tmp)
+                .rotateBytes(100L * 1024 * 1024)
+                .build();
         var metrics = new LoggerMetrics();
 
         LogWriter writer = new LogWriter(cfg, queue, metrics, closed, faulted, terminated);
@@ -181,7 +187,7 @@ final class LogWriterTest {
             VeriLogIoException ex = assertThrows(VeriLogIoException.class, writer::rotate);
 
             assertEquals("io.rotate_failed", ex.getMessageKey());
-            assertTrue(ex.getMessage().contains(cfg.currentFileName));
+            assertTrue(ex.getMessage().contains(cfg.getCurrentFileName()));
 
             // Cause should be the original IOException
             assertTrue(ex.getCause() instanceof IOException);
@@ -195,7 +201,7 @@ final class LogWriterTest {
         var faulted = new AtomicBoolean(false);
         var terminated = new CountDownLatch(1);
 
-        var cfg = newConfig(tmp);
+        var cfg = TestConfigBuilder.configBuilder(tmp).build();
         var writer = new LogWriter(cfg, queue, new LoggerMetrics(), closed, faulted, terminated);
 
         // Replace private 'file' with a mock that throws on close
@@ -219,13 +225,13 @@ final class LogWriterTest {
         var faulted = new AtomicBoolean(false);
         var terminated = new CountDownLatch(1);
 
-        var cfg = newConfig(tmp);
+        var cfg = TestConfigBuilder.configBuilder(tmp).build();
         var writer = new LogWriter(cfg, queue, new LoggerMetrics(), closed, faulted, terminated);
 
         FramedLogFile mockFile = mock(FramedLogFile.class);
         doThrow(new IOException("flush boom")).when(mockFile).flush(true);
         // close succeeds (or also make it throw to cover that catch too)
-         doThrow(new IOException("close boom")).when(mockFile).close();
+        doThrow(new IOException("close boom")).when(mockFile).close();
         setPrivateField(writer, "file", mockFile);
         assertDoesNotThrow(writer::flushAndCloseBestEffort);
 
@@ -241,7 +247,7 @@ final class LogWriterTest {
         var faulted = new AtomicBoolean(false);
         var terminated = new CountDownLatch(1);
 
-        var cfg = newConfig(tmp);
+        var cfg = TestConfigBuilder.configBuilder(tmp).build();
         var writer = new LogWriter(cfg, queue, new LoggerMetrics(), closed, faulted, terminated);
 
         // Force the snapshot branch to see f == null
@@ -266,7 +272,7 @@ final class LogWriterTest {
         var faulted = new AtomicBoolean(false);
         var terminated = new CountDownLatch(1);
 
-        var cfg = newConfig(tmp);
+        var cfg = TestConfigBuilder.configBuilder(tmp).build();
         var writer = new LogWriter(cfg, queue, new LoggerMetrics(), closed, faulted, terminated);
 
         FramedLogFile mockFile = mock(FramedLogFile.class);
@@ -275,7 +281,7 @@ final class LogWriterTest {
         doThrow(boom).when(mockFile).appendEncryptedJson(anyByte(), anyLong(), any(byte[].class));
         // bestEffortFlush should call flush(true)
         // (let flush succeed or throw- either way it’s swallowed by bestEffortFlush)
-         doThrow(new IOException("flush boom")).when(mockFile).flush(true);
+        doThrow(new IOException("flush boom")).when(mockFile).flush(true);
         setPrivateField(writer, "file", mockFile);
 
         Method writeOne = LogWriter.class.getDeclaredMethod("writeOne", LogEvent.class);
@@ -300,7 +306,7 @@ final class LogWriterTest {
         var faulted = new AtomicBoolean(false);
         var terminated = new CountDownLatch(1);
 
-        var cfg = newConfig(tmp);
+        var cfg = TestConfigBuilder.configBuilder(tmp).build();
         var writer = new LogWriter(cfg, queue, new LoggerMetrics(), closed, faulted, terminated);
 
         Method pollEvent = LogWriter.class.getDeclaredMethod("pollEvent");
@@ -338,26 +344,4 @@ final class LogWriterTest {
         f.set(target, value);
     }
 
-    private VeriLoggerConfig newConfig(Path dir) throws Exception {
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
-        kpg.initialize(256);
-        KeyPair kp = kpg.generateKeyPair();
-
-        var cfg = new VeriLoggerConfig();
-        cfg.logDir = dir;
-        cfg.currentFileName = "current.vlog";
-        cfg.filePrefix = "verilog-";
-        cfg.rotateOnStartup = false;
-
-        cfg.rotateBytes = 1024 * 1024;
-        cfg.flushEveryN = 10;
-        cfg.flushEveryMs = 50;
-        cfg.fsyncOnFlush = false;
-
-        cfg.encryptionKey32 = new byte[32]; // test key
-        cfg.aadPrefix = "test-aad";
-
-        cfg.signer = new TestLogSigner(kp.getPrivate(), kp.getPublic());        cfg.actor = "test-actor";
-        return cfg;
-    }
 }

--- a/VeriLogJava/src/test/java/io/github/em/verilog/logger/VeriLoggerTest.java
+++ b/VeriLogJava/src/test/java/io/github/em/verilog/logger/VeriLoggerTest.java
@@ -1,10 +1,13 @@
 package io.github.em.verilog.logger;
 
+import io.github.em.verilog.logger.utils.TestConfigBuilder;
 import io.github.em.verilog.sign.LogSigner;
 import org.junit.jupiter.api.Test;
 
-import java.nio.file.*;
-import java.security.SecureRandom;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.Map;
 
@@ -16,11 +19,12 @@ class VeriLoggerTest {
     void should_write_events_when_logging_and_should_not_throw_when_logging_after_close() throws Exception {
         Path dir = Files.createTempDirectory("verilog-logger-test");
 
-        VeriLoggerConfig cfg = baseCfg(dir);
-        cfg.queueCapacity = 128;
-        cfg.flushEveryN = 1;     // flush frequently for tests
-        cfg.flushEveryMs = 10;
-        cfg.rotateOnStartup = true;
+        VeriLoggerConfig cfg =
+                TestConfigBuilder.configBuilder(dir)
+                        .queueCapacity(1) // flush frequently for tests
+                        .flushEveryMs(10)
+                        .rotateOnStartup(true)
+                        .build();
 
         try (VeriLogger logger = VeriLogger.create(cfg)) {
             for (int i = 0; i < 50; i++) {
@@ -46,13 +50,13 @@ class VeriLoggerTest {
     void should_drop_some_events_when_queue_capacity_is_small_and_mode_is_drop_under_high_load() throws Exception {
         Path dir = Files.createTempDirectory("verilog-logger-drop");
 
-        VeriLoggerConfig cfg = baseCfg(dir);
-        cfg.backpressureMode = VeriLoggerConfig.BackpressureMode.DROP;
-        cfg.offerTimeoutMs = 0;
-        cfg.queueCapacity = 1;      // tiny to force drops
-        cfg.flushEveryN = 1000;
-        cfg.flushEveryMs = 1000;
-
+        VeriLoggerConfig cfg = TestConfigBuilder.configBuilder(dir)
+                .backpressureMode(VeriLoggerConfig.BackpressureMode.DROP)
+                .offerTimeoutMs(0)
+                .queueCapacity(1)
+                .flushEveryN(1000)
+                .flushEveryMs(1000)
+                .build();
         try (VeriLogger logger = VeriLogger.create(cfg)) {
             // Burst a lot of events quickly
             for (int i = 0; i < 50_000; i++) {
@@ -73,11 +77,13 @@ class VeriLoggerTest {
         // create a non-empty "current.vlog"
         Files.write(current, new byte[]{1, 2, 3}, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
 
-        VeriLoggerConfig cfg = baseCfg(dir);
-        cfg.currentFileName = "current.vlog";
-        cfg.rotateOnStartup = true;
-        cfg.flushEveryN = 1;
-        cfg.flushEveryMs = 10;
+        VeriLoggerConfig cfg = TestConfigBuilder.configBuilder(dir)
+                .currentFileName("current.vlog")
+                .rotateOnStartup(true)
+                .flushEveryMs(10)
+                .flushEveryN(10)
+                .build();
+
 
         try (VeriLogger logger = VeriLogger.create(cfg)) {
             logger.info("post-rotate");
@@ -85,7 +91,7 @@ class VeriLoggerTest {
         }
 
         // rotated file should exist (prefix + timestamp)
-        try (DirectoryStream<Path> ds = Files.newDirectoryStream(dir, cfg.filePrefix + "-*.vlog")) {
+        try (DirectoryStream<Path> ds = Files.newDirectoryStream(dir, cfg.getFilePrefix() + "-*.vlog")) {
             boolean found = false;
             for (Path p : ds) {
                 found = true;
@@ -100,12 +106,13 @@ class VeriLoggerTest {
     void should_throw_illegal_state_when_writer_faults_and_fault_mode_is_fail_fast() throws Exception {
         Path dir = Files.createTempDirectory("verilog-logger-fault");
 
-        VeriLoggerConfig cfg = baseCfg(dir);
-        cfg.faultMode = VeriLoggerConfig.FaultMode.FAIL_FAST;
-        cfg.signer = new ThrowingSigner(); // writer will fault when it tries to sign
-        cfg.queueCapacity = 64;
-        cfg.flushEveryN = 1;
-        cfg.flushEveryMs = 10;
+        VeriLoggerConfig cfg = TestConfigBuilder.configBuilder(dir)
+                .faultMode(VeriLoggerConfig.FaultMode.FAIL_FAST)
+                .signer(new ThrowingSigner())// writer will fault when it tries to sign
+                .queueCapacity(64)
+                .flushEveryN(1)
+                .flushEveryMs(10)
+                .build();
 
         try (VeriLogger logger = VeriLogger.create(cfg)) {
             // enqueue something that will fault the writer when processed
@@ -127,21 +134,18 @@ class VeriLoggerTest {
 
     // -------- helpers --------
 
-    private static VeriLoggerConfig baseCfg(Path dir) {
-        VeriLoggerConfig cfg = new VeriLoggerConfig();
-        cfg.logDir = dir;
-        cfg.filePrefix = "app";
-        cfg.currentFileName = "current.vlog";
-        cfg.actor = "test";
-
-        byte[] dek = new byte[32];
-        new SecureRandom().nextBytes(dek);
-        cfg.encryptionKey32 = dek;
-
-        cfg.signer = new TestSigner();
-        // Keep default rotateBytes >= 1MB to satisfy validate()
-        return cfg;
-    }
+//    private static VeriLoggerConfig.Builder baseCfg(Path dir) throws Exception {
+//        byte[] dek = new byte[32];
+//        new SecureRandom().nextBytes(dek);
+//
+//        VeriLoggerConfig cfg = TestConfigBuilder.configBuilder(dir)
+//                .filePrefix("app")
+//                .currentFileName("current.vlog")
+//                .actor("test")
+//                .encryptionKey(dek)
+//                .signer(new TestSigner());
+//        return cfg;
+//    }
 
     private static void waitUntil(BooleanSupplier condition, Duration timeout) throws InterruptedException {
         long deadline = System.currentTimeMillis() + timeout.toMillis();
@@ -157,9 +161,13 @@ class VeriLoggerTest {
     }
 
     private static final class TestSigner implements LogSigner {
-        @Override public String keyId() { return "test-key"; }
+        @Override
+        public String keyId() {
+            return "test-key";
+        }
 
-        @Override public byte[] signEntryHash(byte[] entryHash32) {
+        @Override
+        public byte[] signEntryHash(byte[] entryHash32) {
             // produce deterministic 64 bytes (NOT a real signature- sufficient for writer path)
             byte[] out = new byte[64];
             for (int i = 0; i < out.length; i++) {
@@ -170,8 +178,13 @@ class VeriLoggerTest {
     }
 
     private static final class ThrowingSigner implements LogSigner {
-        @Override public String keyId() { return "throwing-key"; }
-        @Override public byte[] signEntryHash(byte[] entryHash32) {
+        @Override
+        public String keyId() {
+            return "throwing-key";
+        }
+
+        @Override
+        public byte[] signEntryHash(byte[] entryHash32) {
             throw new RuntimeException("boom");
         }
     }

--- a/VeriLogJava/src/test/java/io/github/em/verilog/logger/utils/TestConfigBuilder.java
+++ b/VeriLogJava/src/test/java/io/github/em/verilog/logger/utils/TestConfigBuilder.java
@@ -1,0 +1,29 @@
+package io.github.em.verilog.logger.utils;
+
+import io.github.em.verilog.logger.VeriLoggerConfig;
+
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+
+public class TestConfigBuilder {
+    public static VeriLoggerConfig.Builder configBuilder(Path dir) throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
+        kpg.initialize(256);
+        KeyPair kp = kpg.generateKeyPair();
+
+        return new VeriLoggerConfig.Builder()
+                .logDir(dir)
+                .currentFileName("current.vlog")
+                .filePrefix("verilog-")
+                .rotateOnStartup(true)
+                .rotateBytes(1024 * 1024)
+                .flushEveryN(10)
+                .flushEveryMs(50)
+                .fsyncOnFlush(false)
+                .encryptionKey(new byte[32])
+                .aadPrefix("test-aad")
+                .signer(new TestLogSigner(kp.getPrivate(), kp.getPublic()))
+                .actor("test-actor");
+    }
+}

--- a/VeriLogJava/src/test/java/io/github/em/verilog/logger/utils/TestLogSigner.java
+++ b/VeriLogJava/src/test/java/io/github/em/verilog/logger/utils/TestLogSigner.java
@@ -1,8 +1,11 @@
-package io.github.em.verilog.logger;
+package io.github.em.verilog.logger.utils;
 
 import io.github.em.verilog.errors.VeriLogCryptoException;
 import io.github.em.verilog.sign.LogSigner;
-import org.bouncycastle.asn1.*;
+import org.bouncycastle.asn1.ASN1InputStream;
+import org.bouncycastle.asn1.ASN1Integer;
+import org.bouncycastle.asn1.ASN1Primitive;
+import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.util.encoders.Hex;
 
 import java.io.IOException;
@@ -17,7 +20,7 @@ final class TestLogSigner implements LogSigner {
     private final PrivateKey priv;
     private final String keyId;
 
-    TestLogSigner(PrivateKey priv, PublicKey pub) {
+     TestLogSigner(PrivateKey priv, PublicKey pub) {
         this.priv = priv;
         this.keyId = computeKeyId(pub);
     }


### PR DESCRIPTION
## Description
This PR introduced the builder Pattern for the VerilogConfig and tests adaptations regarding that change.


### Pattern example
```java
VeriLoggerConfig cfg = new VeriLoggerConfig.Builder()
                .logDir(dir)
                .......
                .build;
```